### PR TITLE
Fixing the units of qpoints for Quantum ESPRESSO

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,10 +12,11 @@ This tool leverages the `phonon visualizer`_ developed by Henrique Miranda.
 Contributors
 ============
 
-- Snehal Kumbhar (EPFL) [tool development]
+- Snehal Kumbhar, Elsa Passaro (EPFL) [tool development]
 - Giovanni Pizzi (EPFL) [tool development]
 - Henrique Miranda (UCL, Belgium) [development of the original phonon visualizer]
 - Thibault Sohier (EPFL) [support on the python code and on the examples]
+- Chara Cignarella (EPFL) [bug reporting and fixing]
 
 =======
 License

--- a/compute/__init__.py
+++ b/compute/__init__.py
@@ -12,7 +12,7 @@ from compute.phononweb.qephonon_qetools import QePhononQetools
 import qe_tools # mostly to get its version
 from tools_barebone import __version__ as tools_barebone_version
 
-__version__ = "21.06.0"
+__version__ = "21.07.0"
 
 blueprint = Blueprint('compute', __name__, url_prefix='/compute')
 
@@ -66,6 +66,7 @@ def process_structure():
 
         custom_file = None
         qe_scf_file = None
+        qe_output_file = None
         qe_modes_file = None
 
         if "custom_json_file" in flask.request.files:
@@ -73,6 +74,9 @@ def process_structure():
 
         if "qe_scf_file" in flask.request.files:
             qe_scf_file = flask.request.files["qe_scf_file"]
+
+        if "qe_output_file" in flask.request.files:
+            qe_output_file = flask.request.files["qe_output_file"]
 
         if "qe_modes_file" in flask.request.files:
             qe_modes_file = flask.request.files["qe_modes_file"]
@@ -92,16 +96,19 @@ def process_structure():
                 flask.flash("Uploaded file is empty.")
 
         # CASE 2: QE input
-        elif qe_scf_file and qe_modes_file:
+        elif qe_scf_file and qe_output_file and qe_modes_file:
 
             qe_scf_filename = secure_filename(qe_scf_file.filename)
             qe_scf_file.save(os.path.join(tmp_folder, qe_scf_filename))
+
+            qe_output_filename = secure_filename(qe_output_file.filename)
+            qe_output_file.save(os.path.join(tmp_folder, qe_output_filename))
 
             qe_modes_filename = secure_filename(qe_modes_file.filename)
             qe_modes_file.save(os.path.join(tmp_folder, qe_modes_filename))
 
             try:
-                tmpdata = QePhononQetools("PW", "qe_test", folder=tmp_folder, scf=qe_scf_filename, modes=qe_modes_filename).get_json()
+                tmpdata = QePhononQetools("PW", "qe_test", folder=tmp_folder, scf=qe_scf_filename, scf_output=qe_output_filename, modes=qe_modes_filename).get_json()
                 jsondata =json.loads(tmpdata)
                 if jsondata:
                     return flask.render_template("user_templates/visualizer.html", structure="",

--- a/compute/phononweb/phononweb.py
+++ b/compute/phononweb/phononweb.py
@@ -308,7 +308,8 @@ class Phonon():
                 "eigenvalues": self.eigenvalues,  # eigenvalues (in units of cm-1)
                 "distances": self.distances,  # list distances between the qpoints
                 "highsym_qpts": self.highsym_qpts,  # list of high symmetry qpoints
-                "vectors": self.eigenvectors}  # eigenvectors
+                "vectors": self.eigenvectors, # eigenvectors
+                "alat": getattr(self, 'alat', None)} # alat in angstrom 
 
         return json.dumps(data, cls=JsonEncoder, indent=1)
 

--- a/user_templates/visualizer.html
+++ b/user_templates/visualizer.html
@@ -160,11 +160,14 @@
         <div class="col-sm-6 col-md-6">
             <div class="shadow-box">
                 <div class="metadata-container">
-                    <h3>Lattice parameters (Ångström):</h3>
+                    <h3>Lattice parameters (Å):</h3>
                     <div>
                         <table id="lattice" class="table attribute-table numbers-font-family">
                         </table>
                     </div>
+
+                    {% if 'alat' in jsondata and jsondata.alat is not none %}<h4>Parsed a<sub>lat</sub> from Quantum ESPRESSO: <span style="color: black;"><span>{{jsondata.alat}}</span> Å</span></h4>
+                    <p>Note: This value is parsed from the output file you provided. No check have been performed to validate that the input file and the output file you provided are from the same run. Please double check yourself!</p>{% endif %}
                 </div>
             </div>
         </div>

--- a/user_templates/visualizer_select_structure.html
+++ b/user_templates/visualizer_select_structure.html
@@ -38,7 +38,15 @@
                 </div>
                 <div class='row'>
                     <div class='col-xs-12 col-sm-4'>
-                        <label for="qemodesfile">2. .modes file (matdyn.x output): </label>
+                        <label for="qeoutputfile">2. pw.x or ph.x output file: </label>
+                    </div>
+                    <div class='col-xs-12 col-sm-8'>
+                        <input type="file" name="qe_output_file" size="100">
+                    </div>
+                </div>
+                <div class='row'>
+                    <div class='col-xs-12 col-sm-4'>
+                        <label for="qemodesfile">3. .modes file (matdyn.x output): </label>
                     </div>
                     <div class='col-xs-12 col-sm-8'>
                         <input type="file" name="qe_modes_file" size="100">


### PR DESCRIPTION
In the matdyn.modes, the qpoints are stored in units of
2*pi/alat, where alat is a "lattice parameter" defined
in the Quantum ESPRESSO (QE) run.
This value might not be defined in the input SCF file,
in particular in the case `ibrav=0`. In this case, recent
versions of QE set `alat` equal to the length of the first
lattice vector, but earlier 5.x versions had a different
behavior.
If `ibrav` is not 0, instead, `alat` is set from either
`celldm` (in bohr) or `a` (in angstrom) from the input.

Therefore, there is no reliable way to infer `alat` from
the input. Therefore, the only solution is to ask also to
pass one of the output files (both the pw.x and the ph.x
files contain the information on the `alat`).
This is now parsed, converted from bohr to angstrom, and
used internally to correctly convert qpoints from units
of 2pi/alat in units of 1/angstrom, and then in reduced
coordinates as needed internally.

Note that this issue only exists when parsing Quantum ESPRESSO
files.
Now, for double checking, when the phonons come from a
Quantum ESPRESSO run, we also print the value of alat to the
output HTML page for double checking (NOTE! there is no
consistency check performed at this point that the input
and output files provided are from the same run - only a
warning is shown for the user to double check)

The bug had been already reported in #5 some months ago,
and then reported again by Chiara Cignarella (EPFL) a few
days ago - this fix has been tested together with her.

This fixes #5