### PR TITLE
fixed organization name on DockerHub

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -21,6 +21,9 @@ jobs:
         id: setup
         run: echo "::set-output name=version::${GITHUB_REF#refs/tags/v}"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
@@ -46,8 +49,8 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           push: true
           tags: |
-            ${{ github.repository }}:latest
-            ${{ github.repository }}:${{ steps.setup.outputs.version }}
+            materialscloud/${GITHUB_REPOSITORY#*/}:latest
+            materialscloud/${GITHUB_REPOSITORY#*/}:${{ steps.setup.outputs.version }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 


### PR DESCRIPTION
Fixes #12.
The action was trying to push to Docker Hub the image `materialscloud-org/tools-phonon-dispersion` (name of this GitHub repo) while the tag of the image pushed to Docker Hub should be `materialscloud/tools-phonon-dispersion`.  